### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/ClubActivityManager/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/ClubActivityManager/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $( this.escapeCssMeta(element) ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/suddeNslow/ClubActivityManager/security/code-scanning/5](https://github.com/suddeNslow/ClubActivityManager/security/code-scanning/5)

To fix the problem, we need to ensure that any user-controlled input used in jQuery selectors is properly sanitized to prevent XSS vulnerabilities. Specifically, we should use the `escapeCssMeta` function to sanitize the `element` variable before it is used in the jQuery selector on line 1086.

1. Identify the line where the `element` variable is used in the jQuery selector.
2. Apply the `escapeCssMeta` function to the `element` variable to sanitize it.
3. Ensure that the `escapeCssMeta` function is available and correctly implemented.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
